### PR TITLE
chore: route installs through npm proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
+
 jobs:
   lint_js:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=${NPM_REGISTRY}


### PR DESCRIPTION
## Summary
Routes `bun install` (local + CI) through a configurable npm proxy by reading the registry URL from an `NPM_REGISTRY` env var (locally) / GitHub Actions secret (CI).

## Details
- Adds `.npmrc` with `registry=${NPM_REGISTRY}` so the proxy URL stays out of the repo.
- Both `ci.yml` and `deploy.yml` set `env: NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}` so `bun install --frozen-lockfile` can read it.
- The `NPM_REGISTRY` Actions secret is set on this repo.
- Locally, the var is sourced from a gitignored fish `conf.d` file, so no plaintext URL or token lives in any committed file.