### PR TITLE
chore: enforce 14-day package cooldown via tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 14
     assignees:
       - "wamonroe"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [main]
 
-env:
-  NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
-
 jobs:
   lint_js:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
 
-env:
-  NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
-
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=${NPM_REGISTRY}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+minimumReleaseAge = 1209600  # 14 days in seconds


### PR DESCRIPTION
## Summary
Replaces the proxy-registry CI approach with tooling-layer enforcement of the 14-day package age rule.

## Details
- **`bunfig.toml`** — `minimumReleaseAge = 1209600` (14 days) blocks bun from resolving packages newer than 14 days locally.
- **`.npmrc` removed** — CI installs from public npm; locally MDM-managed `~/.npmrc` still routes through the corporate proxy.
- **`NPM_REGISTRY` env blocks removed** from `ci.yml` and `deploy.yml`.
- **Dependabot `cooldown: default-days: 14`** on the `bun` ecosystem entry — Dependabot never proposes versions younger than 14 days.